### PR TITLE
Fix xcodebuild path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+    branches: ["main", "work"]
+
+jobs:
+  build-test-lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test
+      - name: Lint
+        run: make lint

--- a/CodexSwiftUIApp/Package.swift
+++ b/CodexSwiftUIApp/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "CodexSwiftUIApp",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .executable(name: "CodexSwiftUIApp", targets: ["CodexSwiftUIApp"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "CodexSwiftUIApp",
+            path: "Sources",
+            resources: [],
+            swiftSettings: []
+        ),
+        .testTarget(
+            name: "CodexSwiftUIAppTests",
+            dependencies: ["CodexSwiftUIApp"],
+            path: "Tests"
+        )
+    ]
+)

--- a/CodexSwiftUIApp/Sources/CodexSwiftUIApp/CodexSwiftUIAppApp.swift
+++ b/CodexSwiftUIApp/Sources/CodexSwiftUIApp/CodexSwiftUIAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CodexSwiftUIApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/CodexSwiftUIApp/Sources/CodexSwiftUIApp/ContentView.swift
+++ b/CodexSwiftUIApp/Sources/CodexSwiftUIApp/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/CodexSwiftUIApp/Tests/CodexSwiftUIAppTests.swift
+++ b/CodexSwiftUIApp/Tests/CodexSwiftUIAppTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import CodexSwiftUIApp
+
+final class CodexSwiftUIAppTests: XCTestCase {
+    func testExample() throws {
+        // Placeholder test
+        XCTAssertTrue(true)
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+APP_SCHEME=CodexSwiftUIApp
+PACKAGE_PATH=CodexSwiftUIApp
+
+build:
+	@echo "Building iOS app"
+	cd $(PACKAGE_PATH) && xcodebuild -scheme $(APP_SCHEME) -sdk iphonesimulator -destination 'generic/platform=iOS' build
+
+test:
+	@echo "Running tests on iPhone 16"
+	cd $(PACKAGE_PATH) && xcodebuild -scheme $(APP_SCHEME) -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' test
+
+list:
+	@echo "Listing schemes"
+	cd $(PACKAGE_PATH) && xcodebuild -list
+
+deploy:
+	@echo "Deploying app (placeholder)"
+	# Replace with actual deployment command, e.g., using xcrun altool
+
+lint:
+	@echo "Running SwiftLint"
+	swiftlint
+
+.PHONY: build test list deploy lint

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-
+This repository contains a minimal SwiftUI application for iOS 16 used for demonstration
+purposes. The Makefile provides tasks for building, testing on an iPhone 16 simulator,
+listing available schemes and deploying the app. The CI workflow on GitHub Actions
+uses these tasks to verify the project.


### PR DESCRIPTION
## Summary
- run `xcodebuild` from the Swift package directory instead of relying on -package-path
- target iOS 16 and test using an iPhone 16 simulator

## Testing
- `make list` *(fails: xcodebuild not found)*
- `make build` *(fails: xcodebuild not found)*
- `make test` *(fails: xcodebuild not found)*
- `make lint` *(fails: swiftlint not found)*
- `make deploy`

------
https://chatgpt.com/codex/tasks/task_e_68645d4bb58083329098c17a28965f1e